### PR TITLE
add issue and volume numbers for journal articles

### DIFF
--- a/db/migrate/20160911143333_add_volume_issue_to_papers.rb
+++ b/db/migrate/20160911143333_add_volume_issue_to_papers.rb
@@ -1,0 +1,6 @@
+class AddVolumeIssueToPapers < ActiveRecord::Migration
+  def change
+    add_column :papers, :journal_volume, :string
+    add_column :papers, :issue, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150724032230) do
+ActiveRecord::Schema.define(version: 20160911143333) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,8 @@ ActiveRecord::Schema.define(version: 20150724032230) do
     t.string   "mrf"
     t.string   "layers"
     t.string   "doi"
+    t.string   "journal_volume"
+    t.string   "issue"
   end
 
   add_index "papers", ["slug"], name: "index_papers_on_slug", unique: true, using: :btree

--- a/lib/tasks/bib_export.rake
+++ b/lib/tasks/bib_export.rake
@@ -1,7 +1,7 @@
 require "rexml/document"
 
 def export_volume_mods volume
-	dash = "–"
+	dash = /[–-]+/
 	papers = volume.papers
 	volume_title = volume.title
 	year = volume.year
@@ -137,7 +137,7 @@ def export_volume_mods volume
 end
 
 def export_paper_mods paper
-	dash = "–"
+	dash = /[–-]+/
 	paper_title = paper.title
 	year = paper.year
 	volume_title = paper.volume.title
@@ -214,6 +214,25 @@ def export_paper_mods paper
 		genre_type.text = "workshop publication"
 	elsif (paper.anthology_id[0] == "Q" || paper.anthology_id[0] == "J") 
 		genre_type.text = "academic journal"
+                if (paper.journal_volume)
+                  if (!part)
+                    part = mods.add_element 'part'
+                  end
+                  part_detail_volume = part.add_element 'detail'
+                  part_detail_volume.attributes['type'] = 'volume'
+                  part_detail_volume_number = part_detail_volume.add_element 'number'
+                  part_detail_volume_number.text = paper.journal_volume
+                end
+                if (paper.issue)
+                  if (!part)
+                    part = mods.add_element 'part'
+                  end
+                  part_detail_issue = part.add_element 'detail'
+                  part_detail_issue.attributes['type'] = 'issue'
+                  part_detail_issue_number = part_detail_issue.add_element 'number'
+                  part_detail_issue_number.text = paper.issue
+                end
+
 	else
 		genre_type.text = "conference publication"
 	end

--- a/lib/tasks/xml_import.rake
+++ b/lib/tasks/xml_import.rake
@@ -139,6 +139,35 @@ def load_volume_xml(xml_data)
       if p.elements['doi'] # There is a registered DOI for this paper
         @paper.doi = p.elements['doi'].text
       end
+
+      # volume numbers for journal articles
+      if (p.elements["volume"])
+        # <volume> tag in xml file takes precedence
+        @paper.journal_volume = p.elements["volume"].text
+      elsif @volume.anthology_id[0] == 'J' && @volume.year > 1979
+        # if <volume> tag not found, convert year to volume number for CL
+        @paper.journal_volume = ( @volume.year - 1974 ).to_s
+        # replace "Computational Linguistics, Volume 18, Issue 1"
+        # with    "Computational Linguistics"
+        @volume.title = @volume.title.gsub(/[-–, ]*Volume .*/, '')
+        @volume.save
+      elsif @volume.anthology_id[0] == 'Q'
+        # convert year to volume number for TACL
+        @paper.journal_volume = ( @volume.year - 2012 ).to_s
+        @volume.title = @volume.title.gsub(/[-–, ]*Volume .*/, '')
+        @volume.save
+      end
+
+      # issue numbers for journal articles
+      if (p.elements["issue"])
+        # <issue> tag in xml file takes precedence
+        @paper.issue = p.elements["issue"].text
+      elsif @volume.anthology_id[0] == 'J'
+        # otherwise, the thousands place in the paper id is the issue number for CL
+        @paper.issue = ( p.attributes["id"].to_i / 1000 ).to_s
+        # TACL has no issue number
+      end
+
       #			if p.elements['mrf'] # There is a machine readable layer for this paper
       #				@paper.layers 		= "MRF"
       #				@paper.mrf 			= p.elements['mrf'].text


### PR DESCRIPTION
Fixes issue #18   

Here is a patch to add volume and issue numbers to the
database and to the generated bibtex.  It will accept
<volume> and <issue> tags in the ingested xml files,
but it also figures out the volume and issue numbers
from the current xml files.
